### PR TITLE
Support local, register package

### DIFF
--- a/Sources/LicenseProviderExec/WorkSpacePackage.swift
+++ b/Sources/LicenseProviderExec/WorkSpacePackage.swift
@@ -8,6 +8,7 @@ struct WorkSpacePackage: Decodable, Hashable {
   let name: String
   let location: URL
   let subPath: String
+  let kind: Kind
 
   enum PackageRefCodingKeys: CodingKey {
     case packageRef
@@ -17,6 +18,7 @@ struct WorkSpacePackage: Decodable, Hashable {
   enum CodingKeys: CodingKey {
     case name
     case location
+    case kind
   }
 
   init(from decoder: Decoder) throws {
@@ -30,5 +32,13 @@ struct WorkSpacePackage: Decodable, Hashable {
 
     self.name = try container.decode(String.self, forKey: .name)
     self.location = try container.decode(URL.self, forKey: .location)
+    self.kind = try container.decode(Kind.self, forKey: .location)
+  }
+}
+
+extension WorkSpacePackage {
+  enum Kind: String, Decodable {
+    case remoteSourceControl
+    case fileSystem
   }
 }

--- a/Sources/LicenseProviderExec/WorkSpacePackage.swift
+++ b/Sources/LicenseProviderExec/WorkSpacePackage.swift
@@ -41,5 +41,6 @@ extension WorkSpacePackage {
     case remoteSourceControl
     case localSourceControl
     case fileSystem
+    case registry
   }
 }

--- a/Sources/LicenseProviderExec/WorkSpacePackage.swift
+++ b/Sources/LicenseProviderExec/WorkSpacePackage.swift
@@ -32,7 +32,7 @@ struct WorkSpacePackage: Decodable, Hashable {
 
     self.name = try container.decode(String.self, forKey: .name)
     self.location = try container.decode(URL.self, forKey: .location)
-    self.kind = try container.decode(Kind.self, forKey: .location)
+    self.kind = try container.decode(Kind.self, forKey: .kind)
   }
 }
 

--- a/Sources/LicenseProviderExec/WorkSpacePackage.swift
+++ b/Sources/LicenseProviderExec/WorkSpacePackage.swift
@@ -39,6 +39,7 @@ struct WorkSpacePackage: Decodable, Hashable {
 extension WorkSpacePackage {
   enum Kind: String, Decodable {
     case remoteSourceControl
+    case localSourceControl
     case fileSystem
   }
 }

--- a/Sources/LicenseProviderExec/main.swift
+++ b/Sources/LicenseProviderExec/main.swift
@@ -41,8 +41,15 @@ let workspace = try JSONDecoder().decode(WorkSpace.self, from: jsonData)
 var packages: [WorkSpacePackage: String] = [:]
 
 for package in workspace.packages {
-  let subPath = sourcePackagesPath.appendingPathComponent("checkouts").appendingPathComponent(
-    package.subPath)
+  let subPath: URL = switch package.kind {
+  case .fileSystem:
+    package.location
+  case .remoteSourceControl:
+    sourcePackagesPath
+      .appendingPathComponent("checkouts")
+      .appendingPathComponent(package.subPath)
+  }
+
   let contents = try FileManager.default.contentsOfDirectory(
     at: subPath, includingPropertiesForKeys: nil
   ).filter { path in

--- a/Sources/LicenseProviderExec/main.swift
+++ b/Sources/LicenseProviderExec/main.swift
@@ -41,17 +41,22 @@ let workspace = try JSONDecoder().decode(WorkSpace.self, from: jsonData)
 var packages: [WorkSpacePackage: String] = [:]
 
 for package in workspace.packages {
-  let subPath: URL = switch package.kind {
+  let subPath: URL? = switch package.kind {
   case .localSourceControl, .fileSystem:
     package.location
   case .remoteSourceControl:
     sourcePackagesPath
       .appendingPathComponent("checkouts")
       .appendingPathComponent(package.subPath)
+  case .registry:
+    nil
   }
 
+  guard let subPath else { continue }
+
   let contents = try FileManager.default.contentsOfDirectory(
-    at: subPath, includingPropertiesForKeys: nil
+    at: subPath,
+    includingPropertiesForKeys: nil
   ).filter { path in
     let pathWithoutExtension = path.deletingPathExtension()
 

--- a/Sources/LicenseProviderExec/main.swift
+++ b/Sources/LicenseProviderExec/main.swift
@@ -42,7 +42,7 @@ var packages: [WorkSpacePackage: String] = [:]
 
 for package in workspace.packages {
   let subPath: URL = switch package.kind {
-  case .fileSystem:
+  case .localSourceControl, .fileSystem:
     package.location
   case .remoteSourceControl:
     sourcePackagesPath


### PR DESCRIPTION
## Support Package Location other than `remoteSourceControl`.

Support `localSourceControl`, `fileSystem`, `registry`

- fileSystem
  - `.package(path: "/Users/user/GitHub/LicenseProvider")`
- localSourceControl
  - `.package(url: "/Users/user/GitHub/LicenseProvider", branch: "main")`
- registry
  - `.package(id: "LicenseProvider", from: "1.0.0")`

